### PR TITLE
Corrected Pandoc command line parameter.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,3 +5,7 @@
 # 1.0.2
 
 -   Change default Markdown flavor from `markdown_strict` to `markdown`.
+
+# 1.0.3
+
+-   Change Pandoc command line parameter `--reference-docx` to `--reference-doc`.

--- a/foliant/backends/pandoc.py
+++ b/foliant/backends/pandoc.py
@@ -81,7 +81,7 @@ class Backend(BaseBackend):
 
         reference_docx = self._pandoc_config.get('reference_docx')
         if reference_docx:
-            components.append(f'--reference-docx={reference_docx}')
+            components.append(f'--reference-doc={reference_docx}')
 
         components.append(f'--output {self.get_slug()}.docx')
         components.append(self._get_filters_string())

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name='foliantcontrib.pandoc',
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    version='1.0.2',
+    version='1.0.3',
     author='Konstantin Molchanov',
     author_email='moigagoo@live.com',
     url='https://github.com/foliant-docs/foliantcontrib',


### PR DESCRIPTION
The `--reference-docx` Pandoc option has been changed to `--reference-doc`. See http://pandoc.org/MANUAL.html#options-affecting-specific-writers.

In case of use `--reference-docx` parameter, Pandoc outputs:

```
Build failed: --reference-docx has been removed. Use --reference-doc instead.
Try pandoc --help for more information.
```